### PR TITLE
feat: parallelize validations and return validation result and message

### DIFF
--- a/src/Devantler.KubernetesValidator.ClientSide.Core/IKubernetesClientSideValidator.cs
+++ b/src/Devantler.KubernetesValidator.ClientSide.Core/IKubernetesClientSideValidator.cs
@@ -11,5 +11,5 @@ public interface IKubernetesClientSideValidator
   /// <param name="directoryPath"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  Task<bool> ValidateAsync(string directoryPath, CancellationToken cancellationToken = default);
+  Task<(bool, string)> ValidateAsync(string directoryPath, CancellationToken cancellationToken = default);
 }

--- a/src/Devantler.KubernetesValidator.ClientSide.Schemas/Devantler.KubernetesValidator.ClientSide.Schemas.csproj
+++ b/src/Devantler.KubernetesValidator.ClientSide.Schemas/Devantler.KubernetesValidator.ClientSide.Schemas.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.KustomizeCLI" Version="1.3.0" />
+    <PackageReference Include="Devantler.KustomizeCLI" Version="1.3.1" />
     <PackageReference Include="Devantler.KubeconformCLI" Version="1.5.0" />
   </ItemGroup>
 

--- a/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/SchemaValidatorTests/ValidateAsyncTests.cs
+++ b/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/SchemaValidatorTests/ValidateAsyncTests.cs
@@ -20,10 +20,11 @@ public class ValidateAsyncTests
     var cancellationToken = new CancellationToken();
 
     // Act
-    bool result = await validator.ValidateAsync(directoryPath, cancellationToken);
+    var (result, message) = await validator.ValidateAsync(directoryPath, cancellationToken);
 
     // Assert
     Assert.True(result);
+    Assert.Empty(message);
   }
 
   /// <summary>
@@ -31,7 +32,7 @@ public class ValidateAsyncTests
   /// </summary>
   /// <returns></returns>
   [Fact]
-  public async Task ValidateAsync_WithInvalidYamlFiles_ShouldThrowYamlSyntaxValidatorException()
+  public async Task ValidateAsync_WithInvalidYamlFiles_ShouldReturnFalse()
   {
     // Arrange
     var validator = new SchemaValidator();
@@ -39,9 +40,10 @@ public class ValidateAsyncTests
     var cancellationToken = new CancellationToken();
 
     // Act
-    var task = new Func<Task>(() => validator.ValidateAsync(directoryPath, cancellationToken));
+    var (result, message) = await validator.ValidateAsync(directoryPath, cancellationToken);
 
     // Assert
-    var ex = await Assert.ThrowsAsync<CommandExecutionException>(task);
+    Assert.False(result);
+    Assert.NotEmpty(message);
   }
 }

--- a/tests/Devantler.KubernetesValidator.ClientSide.YamlSyntax.Tests/YamlSyntaxValidatorTests/ValidateAsyncTests.cs
+++ b/tests/Devantler.KubernetesValidator.ClientSide.YamlSyntax.Tests/YamlSyntaxValidatorTests/ValidateAsyncTests.cs
@@ -18,10 +18,11 @@ public class ValidateAsyncTests
     var cancellationToken = new CancellationToken();
 
     // Act
-    bool result = await validator.ValidateAsync(directoryPath, cancellationToken);
+    var (isValid, message) = await validator.ValidateAsync(directoryPath, cancellationToken);
 
     // Assert
-    Assert.True(result);
+    Assert.True(isValid);
+    Assert.Empty(message);
   }
 
   /// <summary>
@@ -29,7 +30,7 @@ public class ValidateAsyncTests
   /// </summary>
   /// <returns></returns>
   [Fact]
-  public async Task ValidateAsync_WithInvalidYamlFiles_ShouldThrowYamlSyntaxValidatorException()
+  public async Task ValidateAsync_WithInvalidYamlFiles_ShouldReturnFalse()
   {
     // Arrange
     var validator = new YamlSyntaxValidator();
@@ -37,9 +38,10 @@ public class ValidateAsyncTests
     var cancellationToken = new CancellationToken();
 
     // Act
-    var task = new Func<Task>(() => validator.ValidateAsync(directoryPath, cancellationToken));
+    var (isValid, message) = await validator.ValidateAsync(directoryPath, cancellationToken);
 
     // Assert
-    _ = await Assert.ThrowsAsync<YamlSyntaxValidatorException>(task);
+    Assert.False(isValid);
+    Assert.NotEmpty(message);
   }
 }


### PR DESCRIPTION
Modify the `ValidateAsync` method across multiple validators to return a tuple containing the validation result and a message. Update tests to reflect these changes. Upgrade the `Devantler.KustomizeCLI` package version.