### PR TITLE
feat: enhance ValidateAsync method with ignore patterns and improved error messaging

### DIFF
--- a/src/Devantler.KubernetesValidator.ClientSide.Core/IKubernetesClientSideValidator.cs
+++ b/src/Devantler.KubernetesValidator.ClientSide.Core/IKubernetesClientSideValidator.cs
@@ -9,7 +9,8 @@ public interface IKubernetesClientSideValidator
   /// Validates the specified directory path.
   /// </summary>
   /// <param name="directoryPath"></param>
+  /// <param name="ignore"></param>
   /// <param name="cancellationToken"></param>
   /// <returns></returns>
-  Task<(bool, string)> ValidateAsync(string directoryPath, CancellationToken cancellationToken = default);
+  Task<(bool, string)> ValidateAsync(string directoryPath, string[]? ignore = default, CancellationToken cancellationToken = default);
 }

--- a/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/SchemaValidatorTests/ValidateAsyncTests.cs
+++ b/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/SchemaValidatorTests/ValidateAsyncTests.cs
@@ -45,10 +45,10 @@ public class ValidateAsyncTests
     // Assert
     Assert.False(result);
     Assert.Contains(
-      "clusters/ksail-default/flux-system/kustomization.yaml - Error: accumulating resources: accumulation err='accumulating resources from 'ddd': open " +
-      "/Users/nikolaiemildamm/git-personal/monorepo/libraries/dotnet-kubernetes-validator/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/bin/Debug/net9.0/osx-arm64/assets/k8s-invalid/clusters/ksail-default/flux-system/ddd: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on " +
-      "'/Users/nikolaiemildamm/git-personal/monorepo/libraries/dotnet-kubernetes-validator/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/bin/Debug/net9.0/osx-arm64/assets/k8s-invalid/clusters/ksail-default/flux-system/ddd' : lstat " +
-      "/Users/nikolaiemildamm/git-personal/monorepo/libraries/dotnet-kubernetes-validator/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/bin/Debug/net9.0/osx-arm64/assets/k8s-invalid/clusters/ksail-default/flux-system/ddd: no such file or directory\n",
+      $"clusters/ksail-default/flux-system/kustomization.yaml - Error: accumulating resources: accumulation err='accumulating resources from 'ddd': open " +
+      $"{Path.Combine(AppContext.BaseDirectory, "assets/k8s-invalid/clusters/ksail-default/flux-system/ddd")}: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on " +
+      $"'{Path.Combine(AppContext.BaseDirectory, "assets/k8s-invalid/clusters/ksail-default/flux-system/ddd")}' : lstat " +
+      $"{Path.Combine(AppContext.BaseDirectory, "assets/k8s-invalid/clusters/ksail-default/flux-system/ddd")}: no such file or directory\n",
       message, StringComparison.OrdinalIgnoreCase);
   }
 }

--- a/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/SchemaValidatorTests/ValidateAsyncTests.cs
+++ b/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/SchemaValidatorTests/ValidateAsyncTests.cs
@@ -45,8 +45,8 @@ public class ValidateAsyncTests
     // Assert
     Assert.False(result);
     Assert.Contains(
-      $"clusters/ksail-default/flux-system/kustomization.yaml - Error: accumulating resources: accumulation err='accumulating resources from 'ddd': open " +
-      $"{Path.Combine(AppContext.BaseDirectory, "assets/k8s-invalid/clusters/ksail-default/flux-system/ddd")}: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on " +
+      $"clusters{Path.DirectorySeparatorChar}ksail-default{Path.DirectorySeparatorChar}flux-system{Path.DirectorySeparatorChar}kustomization.yaml - Error: accumulating resources: accumulation err='accumulating resources from 'ddd': open " +
+      $"{Path.Combine(AppContext.BaseDirectory, $"assets/k8s-invalid/clusters/ksail-default/flux-system/ddd")}: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on " +
       $"'{Path.Combine(AppContext.BaseDirectory, "assets/k8s-invalid/clusters/ksail-default/flux-system/ddd")}' : lstat " +
       $"{Path.Combine(AppContext.BaseDirectory, "assets/k8s-invalid/clusters/ksail-default/flux-system/ddd")}: no such file or directory\n",
       message, StringComparison.OrdinalIgnoreCase);

--- a/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/SchemaValidatorTests/ValidateAsyncTests.cs
+++ b/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/SchemaValidatorTests/ValidateAsyncTests.cs
@@ -20,7 +20,7 @@ public class ValidateAsyncTests
     var cancellationToken = new CancellationToken();
 
     // Act
-    var (result, message) = await validator.ValidateAsync(directoryPath, cancellationToken);
+    var (result, message) = await validator.ValidateAsync(directoryPath, cancellationToken: cancellationToken);
 
     // Assert
     Assert.True(result);
@@ -40,10 +40,15 @@ public class ValidateAsyncTests
     var cancellationToken = new CancellationToken();
 
     // Act
-    var (result, message) = await validator.ValidateAsync(directoryPath, cancellationToken);
+    var (result, message) = await validator.ValidateAsync(directoryPath, cancellationToken: cancellationToken);
 
     // Assert
     Assert.False(result);
-    Assert.NotEmpty(message);
+    Assert.Contains(
+      "clusters/ksail-default/flux-system/kustomization.yaml - Error: accumulating resources: accumulation err='accumulating resources from 'ddd': open " +
+      "/Users/nikolaiemildamm/git-personal/monorepo/libraries/dotnet-kubernetes-validator/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/bin/Debug/net9.0/osx-arm64/assets/k8s-invalid/clusters/ksail-default/flux-system/ddd: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on " +
+      "'/Users/nikolaiemildamm/git-personal/monorepo/libraries/dotnet-kubernetes-validator/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/bin/Debug/net9.0/osx-arm64/assets/k8s-invalid/clusters/ksail-default/flux-system/ddd' : lstat " +
+      "/Users/nikolaiemildamm/git-personal/monorepo/libraries/dotnet-kubernetes-validator/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/bin/Debug/net9.0/osx-arm64/assets/k8s-invalid/clusters/ksail-default/flux-system/ddd: no such file or directory\n",
+      message, StringComparison.OrdinalIgnoreCase);
   }
 }

--- a/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/SchemaValidatorTests/ValidateAsyncTests.cs
+++ b/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/SchemaValidatorTests/ValidateAsyncTests.cs
@@ -45,10 +45,7 @@ public class ValidateAsyncTests
     // Assert
     Assert.False(result);
     Assert.Contains(
-      $"clusters{Path.DirectorySeparatorChar}ksail-default{Path.DirectorySeparatorChar}flux-system{Path.DirectorySeparatorChar}kustomization.yaml - Error: accumulating resources: accumulation err='accumulating resources from 'ddd': open " +
-      $"{Path.Combine(AppContext.BaseDirectory, $"assets/k8s-invalid/clusters/ksail-default/flux-system/ddd")}: no such file or directory': must build at directory: not a valid directory: evalsymlink failure on " +
-      $"'{Path.Combine(AppContext.BaseDirectory, "assets/k8s-invalid/clusters/ksail-default/flux-system/ddd")}' : lstat " +
-      $"{Path.Combine(AppContext.BaseDirectory, "assets/k8s-invalid/clusters/ksail-default/flux-system/ddd")}: no such file or directory\n",
+      $"clusters{Path.DirectorySeparatorChar}ksail-default{Path.DirectorySeparatorChar}flux-system{Path.DirectorySeparatorChar}kustomization.yaml - Error: accumulating resources: accumulation err='accumulating resources from 'ddd':",
       message, StringComparison.OrdinalIgnoreCase);
   }
 }

--- a/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/assets/k8s-invalid/apps/kustomization.yaml
+++ b/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/assets/k8s-invalid/apps/kustomization.yaml
@@ -1,4 +1,4 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: [
+resources: []

--- a/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/assets/k8s-invalid/clusters/ksail-default/flux-system/kustomization.yaml
+++ b/tests/Devantler.KubernetesValidator.ClientSide.Schemas.Tests/assets/k8s-invalid/clusters/ksail-default/flux-system/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- apps.yaml {}
-- infrastructure.yaml
-- infrastructure-controllers.yaml
+ - ddd

--- a/tests/Devantler.KubernetesValidator.ClientSide.YamlSyntax.Tests/YamlSyntaxValidatorTests/ValidateAsyncTests.cs
+++ b/tests/Devantler.KubernetesValidator.ClientSide.YamlSyntax.Tests/YamlSyntaxValidatorTests/ValidateAsyncTests.cs
@@ -18,7 +18,7 @@ public class ValidateAsyncTests
     var cancellationToken = new CancellationToken();
 
     // Act
-    var (isValid, message) = await validator.ValidateAsync(directoryPath, cancellationToken);
+    var (isValid, message) = await validator.ValidateAsync(directoryPath, cancellationToken: cancellationToken);
 
     // Assert
     Assert.True(isValid);
@@ -38,10 +38,10 @@ public class ValidateAsyncTests
     var cancellationToken = new CancellationToken();
 
     // Act
-    var (isValid, message) = await validator.ValidateAsync(directoryPath, cancellationToken);
+    var (isValid, message) = await validator.ValidateAsync(directoryPath, cancellationToken: cancellationToken);
 
     // Assert
     Assert.False(isValid);
-    Assert.NotEmpty(message);
+    Assert.Contains("apps/kustomization.yaml - While parsing a node, did not find expected node content.", message, StringComparison.Ordinal);
   }
 }

--- a/tests/Devantler.KubernetesValidator.ClientSide.YamlSyntax.Tests/YamlSyntaxValidatorTests/ValidateAsyncTests.cs
+++ b/tests/Devantler.KubernetesValidator.ClientSide.YamlSyntax.Tests/YamlSyntaxValidatorTests/ValidateAsyncTests.cs
@@ -42,6 +42,6 @@ public class ValidateAsyncTests
 
     // Assert
     Assert.False(isValid);
-    Assert.Contains("apps/kustomization.yaml - While parsing a node, did not find expected node content.", message, StringComparison.Ordinal);
+    Assert.Contains($"apps{Path.DirectorySeparatorChar}kustomization.yaml - While parsing a node, did not find expected node content.", message, StringComparison.Ordinal);
   }
 }


### PR DESCRIPTION
Enhance the `ValidateAsync` method to support ignore patterns for file validation and improve error messaging for better clarity. This update allows users to specify files to ignore during validation, streamlining the process and providing more informative feedback on errors.