### PR TITLE
fix: improve error messaging with full path in validation failures

### DIFF
--- a/src/Devantler.KubernetesValidator.ClientSide.Schemas/SchemaValidator.cs
+++ b/src/Devantler.KubernetesValidator.ClientSide.Schemas/SchemaValidator.cs
@@ -88,15 +88,13 @@ public class SchemaValidator : IKubernetesClientSideValidator
         var result = await kustomizeCommand.ExecuteBufferedAsync(cancellationToken).ConfigureAwait(false);
         if (result.ExitCode != 0)
         {
-          var relativePath = Path.GetRelativePath(directoryPath, kustomizationPath);
-          return (false, $"{relativePath}{Kustomization} - {result.StandardOutput + result.StandardError}");
+          return (false, $"{Path.Combine(kustomizationPath, Kustomization)} - {result.StandardOutput + result.StandardError}");
         }
         var kubeconformCommand = result.StandardOutput | kubeconformCmd;
         result = await kubeconformCommand.ExecuteBufferedAsync(cancellationToken).ConfigureAwait(false);
         if (result.ExitCode != 0)
         {
-          var relativePath = Path.GetRelativePath(directoryPath, kustomizationPath);
-          return (false, $"{relativePath}{Kustomization} - {result.StandardOutput + result.StandardError}");
+          return (false, $"{Path.Combine(kustomizationPath, Kustomization)} - {result.StandardOutput + result.StandardError}");
         }
         return (true, string.Empty);
       });

--- a/src/Devantler.KubernetesValidator.ClientSide.YamlSyntax/YamlSyntaxValidator.cs
+++ b/src/Devantler.KubernetesValidator.ClientSide.YamlSyntax/YamlSyntaxValidator.cs
@@ -41,8 +41,7 @@ public class YamlSyntaxValidator : IKubernetesClientSideValidator
 #pragma warning disable CA1031 // Do not catch general exception types
       catch (Exception ex)
       {
-        var relativePath = Path.GetRelativePath(directoryPath, manifestPath);
-        return (false, $"{relativePath} - {ex.Message}");
+        return (false, $"{manifestPath} - {ex.Message}");
       }
 #pragma warning restore CA1031 // Do not catch general exception types
 


### PR DESCRIPTION
Enhance error messages in the schema and YAML syntax validators by including the full path instead of a relative path, providing clearer context for validation failures.