### PR TITLE
fix: silence kubeconform output during validation execution

### DIFF
--- a/src/Devantler.KubernetesValidator.ClientSide.Schemas/SchemaValidator.cs
+++ b/src/Devantler.KubernetesValidator.ClientSide.Schemas/SchemaValidator.cs
@@ -52,7 +52,7 @@ public class SchemaValidator : IKubernetesClientSideValidator
       var arguments = kubeconformFlags.Concat(kubeconformConfig).Concat([file]);
       try
       {
-        await Kubeconform.RunAsync([.. arguments], silent: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+        await Kubeconform.RunAsync([.. arguments], silent: true, cancellationToken: cancellationToken).ConfigureAwait(false);
         return (true, string.Empty);
       }
 #pragma warning disable CA1031 // Do not catch general exception types


### PR DESCRIPTION
Silence the output of kubeconform during validation to reduce noise in logs.